### PR TITLE
Fetch data from google sheet instead of Carto

### DIFF
--- a/index.html
+++ b/index.html
@@ -97,6 +97,9 @@
     <!-- import the Mustache library -->
     <script src="https://cdnjs.cloudflare.com/ajax/libs/mustache.js/3.0.0/mustache.min.js"></script>
 
+    <!-- Load d3-tsv -->
+    <script src="https://d3js.org/d3-dsv.v1.min.js"></script>
+
     <!-- Load our JavaScript -->
     <script src="./script.js"></script>
   </body>

--- a/script.js
+++ b/script.js
@@ -6,22 +6,8 @@ console.clear();
 /******************************************
  * DATA SOURCES
  *****************************************/
-
-// the base URI for the CARTO SQL API
-const apiBaseURI = "https://ampitup.carto.com:443/api/v2/sql";
-
-// SQL query to pass to the CARTO API
-const evictionMoratoriumsQuery =
-  "SELECT " +
-  "cartodb_id, " +
-  "(CASE WHEN passed IS TRUE THEN 'Yes' ELSE 'No' END) AS passed, " +
-  "municipality, lat, lon, link, policy_summary, " +
-  "policy_type, start, _end, state, admin_scale " +
-  "FROM " +
-  "public.emergency_tenant_protections_carto_sync_do_not_edit;";
-
-// complete URI to pass to fetch()
-const evictionMoratoriumDataURI = `${apiBaseURI}?q=${evictionMoratoriumsQuery}`;
+const sheetId = "1AkYjbnLbWW83LTm6jcsRjg78hRVxWsSKQv1eSssDHSM";
+const sheetURI = `https://docs.google.com/spreadsheets/d/${sheetId}/export?format=csv&id=${sheetId}`;
 
 // states geojson url
 const statesGeoJsonURI = "./states.geojson";
@@ -33,7 +19,6 @@ const statesGeoJsonURI = "./states.geojson";
 // options for configuring the Leaflet map
 // don't add the default zoom ui and attribution as they're customized first then added layer
 const mapOptions = { zoomControl: false, attributionControl: false };
-
 
 // global styling variables
 const strokeWeight = 1.5;
@@ -56,7 +41,9 @@ const attribution = L.control
 const zoomControl = L.control.zoom({ position: "bottomright" }).addTo(map);
 
 // Map layers control: add the layers later after their data has been fetched
-const layersControl = L.control.layers(null, null, {position: 'topright', collapsed: false}).addTo(map);
+const layersControl = L.control
+  .layers(null, null, { position: "topright", collapsed: false })
+  .addTo(map);
 
 // Get the popup template from the HTML.
 // We can do this here because the template will never change.
@@ -74,17 +61,16 @@ L.tileLayer(
  * FETCH DATA SOURCES
  *****************************************/
 
-Promise.all(
-  // map our data URIs to Fetch requests, then handle them once they've completed (or errored)
-  [evictionMoratoriumDataURI, statesGeoJsonURI].map(uri =>
-    fetch(uri).then(res => {
-      if (!res.ok) {
-        throw new Error("Network request error with data fetch");
-      }
-      return res.json();
-    })
-  )
-)
+Promise.all([
+  fetch(sheetURI).then(res => {
+    if (!res.ok) throw Error("Unable to fetch moratoriums sheet data");
+    return res.text();
+  }),
+  fetch(statesGeoJsonURI).then(res => {
+    if (!res.ok) throw Error("Unable to fetch states geojson");
+    return res.json();
+  })
+])
   .then(handleData)
   .catch(error => console.log(error));
 
@@ -92,12 +78,16 @@ Promise.all(
  * HANDLE DATA ASYNC RESPONSES
  *****************************************/
 
-function handleData([cartoData, statesGeoJson]) {
-  // seperate out the states data from the localities data
-  const { rows } = cartoData;
+function handleData([sheetsText, statesGeoJson]) {
+  const rows = d3.csvParse(sheetsText, d3.autoType);
+  console.log(rows);
 
   const statesData = rows
     .filter(row => row.admin_scale === "State")
+    .map(({ passed, ...rest }) => ({
+      passed: passed === "TRUE" ? "Yes" : "No",
+      ...rest
+    }))
     .reduce((acc, { state, ...rest }) => {
       return acc.set(state, rest);
     }, new Map());

--- a/script.js
+++ b/script.js
@@ -6,7 +6,10 @@ console.clear();
 /******************************************
  * DATA SOURCES
  *****************************************/
+// unique id of the sheet that imports desired columns from the form responses sheet
 const sheetId = "1AkYjbnLbWW83LTm6jcsRjg78hRVxWsSKQv1eSssDHSM";
+
+// the URI that grabs the sheet text formatted as a CSV
 const sheetURI = `https://docs.google.com/spreadsheets/d/${sheetId}/export?format=csv&id=${sheetId}`;
 
 // states geojson url


### PR DESCRIPTION
Fixes #1 

This should solve the problem of Carto failing to correctly sync with the Google Sheet that references the desired columns from the Google Form responses.

To implement this I did the following:

1. made the sheet with the form responses only accessible to members of the AEMP Drive folder.

2. used a [URL for this sheet](https://docs.google.com/spreadsheets/d/1AkYjbnLbWW83LTm6jcsRjg78hRVxWsSKQv1eSssDHSM/edit#gid=0) that requests it formatted as a CSV file

3. parse the CSV using `d3-tsv`