### PR TITLE
fixed name of resources in rent strike infowindow

### DIFF
--- a/index.html
+++ b/index.html
@@ -164,11 +164,11 @@
           <p><strong>Start: </strong>{{Start}}</p>
         </div>
         {{/Start}}
-        {{#Landlord}}
+        {{#Resources}}
         <div>
-          <p><strong>Landlord: </strong>{{Landlord}}</p>
+          <p><strong>Resources: </strong>{{Resources}}</p>
         </div>
-        {{/Landlord}}
+        {{/Resources}}
       </div>
     </script>
 


### PR DESCRIPTION
We were asked to remove the Landlord info from the public map, and instead show local resources that people mention. I already made this change with the rent strike sheet feeding the map, so just need the word "Landlord" replaced with "Resources"