### PR TITLE
Display layers in correct order

### DIFF
--- a/script.js
+++ b/script.js
@@ -343,6 +343,17 @@ function handleData([
     .addOverlay(states, "States")
     .addOverlay(rentStrikes, "Rent Strikes");
 
+   const dataLayersOrder = {
+     states,
+     localities,
+     rentStrikes,
+   };
+
+   // Apply correct relative order of layers when adding from control
+   map.on('overlayadd', function () {
+     fixZOrder(dataLayersOrder);
+   });
+
   if (!mapConfig.states) {
     map.removeLayer(states);
   }
@@ -508,4 +519,23 @@ function handleRentStrikeLayer(geoJson) {
   map.addLayer(rentStrikeLayerMarkers);
 
   return rentStrikeLayerMarkers;
+}
+
+/**
+ * Ensure that layers are displayed in the correct Z-Order
+ * @param {any} dataLayers Object that holds the ordered references to the layer groups toggled by the layer control
+ **/
+function fixZOrder(dataLayers) {
+    // use the order in the dataLayers object to define the z-order
+    Object.keys(dataLayers).forEach(function (key) {
+        // check if the layer has been added to the map, if it hasn't then do nothing
+        const layerGroup = dataLayers[key];
+        const hasLayers =
+          layerGroup._layers && Object.keys(layerGroup._layers).length > 0;
+        const hasVisibleLayers =
+          hasLayers &&
+          layerGroup._layers[Object.keys(layerGroup._layers)[0]]._path;
+        // If the layers are set to be visible, bring them to the front
+        if (hasVisibleLayers) { layerGroup.bringToFront() };
+    });
 }

--- a/script.js
+++ b/script.js
@@ -524,16 +524,16 @@ function handleRentStrikeLayer(geoJson) {
 
 // Ensure that layers are displayed in the correct Z-Order
 function fixZOrder(dataLayers) {
-    // Use the order in the dataLayers object to define the z-order
-    dataLayers.forEach(function (layerGroup) {
-        const hasLayers =
-          layerGroup._layers && 
-          Object.keys(layerGroup._layers).length > 0;
-        const hasVisibleLayers =
-          hasLayers &&
-          layerGroup._layers[Object.keys(layerGroup._layers)[0]]._path &&
-          layerGroup._layers[Object.keys(layerGroup._layers)[0]]._path.parentNode;
-        // If if the layer group has been added to the map, bring it to the front
-        if (hasVisibleLayers) { layerGroup.bringToFront() };
-    });
+  // Use the order in the dataLayers object to define the z-order
+  dataLayers.forEach(function (layerGroup) {
+    const hasLayers =
+      layerGroup._layers && 
+      Object.keys(layerGroup._layers).length > 0;
+    const hasVisibleLayers =
+      hasLayers &&
+      layerGroup._layers[Object.keys(layerGroup._layers)[0]]._path &&
+      layerGroup._layers[Object.keys(layerGroup._layers)[0]]._path.parentNode;
+    // If if the layer group has been added to the map, bring it to the front
+    if (hasVisibleLayers) { layerGroup.bringToFront() };
+  });
 }

--- a/script.js
+++ b/script.js
@@ -344,12 +344,9 @@ function handleData([
     .addOverlay(rentStrikes, "Rent Strikes");
 
   // Apply correct relative order of layers when adding from control.
-  map.on('overlayadd', function () {
+  map.on("overlayadd", function () {
     // Top of list is top layer
-    fixZOrder([
-      localities, 
-      states,
-    ]);
+    fixZOrder([localities, states]);
   });
 
   if (!mapConfig.states) {
@@ -519,15 +516,11 @@ function handleRentStrikeLayer(geoJson) {
   return rentStrikeLayerMarkers;
 }
 
-// Ensure that layers are displayed in the correct Z-Order
+// Ensures that map overlay pane layers are displayed in the correct Z-Order
 function fixZOrder(dataLayers) {
-  dataLayers
-    // Reverse layers so that top of list is the top layer
-    .reverse()
-    .forEach(function (layerGroup) { 
-      // If if the layer group has been added to the map, bring it to the front
-      if (map.hasLayer(layerGroup)) {
-        layerGroup.bringToFront();
-      }
-    });
+  dataLayers.forEach(function (layerGroup) {
+    if (map.hasLayer(layerGroup)) {
+      layerGroup.bringToBack();
+    }
+  });
 }

--- a/script.js
+++ b/script.js
@@ -531,8 +531,8 @@ function fixZOrder(dataLayers) {
         Object.keys(layerGroup._layers).length > 0;
       const hasVisibleLayers =
         hasLayers &&
-        layerGroup._layers[Object.keys(layerGroup._layers)[0]]._path != null &&
-        layerGroup._layers[Object.keys(layerGroup._layers)[0]]._path.parentNode != null;
+        Object.values(layerGroup._layers)[0]._path != null &&
+        Object.values(layerGroup._layers)[0]._path.parentNode != null;
       // If if the layer group has been added to the map, bring it to the front
       if (hasVisibleLayers) { layerGroup.bringToFront() };
     });

--- a/script.js
+++ b/script.js
@@ -343,17 +343,15 @@ function handleData([
     .addOverlay(states, "States")
     .addOverlay(rentStrikes, "Rent Strikes");
 
-  // Order of how layers are displayed. Last is on top
-  const dataLayersOrder = [
-     states,
-     localities,
-     rentStrikes,
-  ];
-
-   // Apply correct relative order of layers when adding from control
-   map.on('overlayadd', function () {
-     fixZOrder(dataLayersOrder);
-   });
+  // Apply correct relative order of layers when adding from control.
+  map.on('overlayadd', function () {
+    // Top of list is top layer
+    fixZOrder([
+      rentStrikes, 
+      localities, 
+      states
+    ]);
+  });
 
   if (!mapConfig.states) {
     map.removeLayer(states);
@@ -524,16 +522,18 @@ function handleRentStrikeLayer(geoJson) {
 
 // Ensure that layers are displayed in the correct Z-Order
 function fixZOrder(dataLayers) {
-  // Use the order in the dataLayers object to define the z-order
-  dataLayers.forEach(function (layerGroup) {
-    const hasLayers =
-      layerGroup._layers != null && 
-      Object.keys(layerGroup._layers).length > 0;
-    const hasVisibleLayers =
-      hasLayers &&
-      layerGroup._layers[Object.keys(layerGroup._layers)[0]]._path != null &&
-      layerGroup._layers[Object.keys(layerGroup._layers)[0]]._path.parentNode != null;
-    // If if the layer group has been added to the map, bring it to the front
-    if (hasVisibleLayers) { layerGroup.bringToFront() };
-  });
+  dataLayers
+    // Reverse layers so that top of list is the top layer
+    .reverse()
+    .forEach(function (layerGroup) {
+      const hasLayers =
+        layerGroup._layers != null && 
+        Object.keys(layerGroup._layers).length > 0;
+      const hasVisibleLayers =
+        hasLayers &&
+        layerGroup._layers[Object.keys(layerGroup._layers)[0]]._path != null &&
+        layerGroup._layers[Object.keys(layerGroup._layers)[0]]._path.parentNode != null;
+      // If if the layer group has been added to the map, bring it to the front
+      if (hasVisibleLayers) { layerGroup.bringToFront() };
+    });
 }

--- a/script.js
+++ b/script.js
@@ -522,14 +522,10 @@ function handleRentStrikeLayer(geoJson) {
   return rentStrikeLayerMarkers;
 }
 
-/**
- * Ensure that layers are displayed in the correct Z-Order
- * @param {any} dataLayers Object that holds the ordered references to the layer groups toggled by the layer control
- **/
+// Ensure that layers are displayed in the correct Z-Order
 function fixZOrder(dataLayers) {
-    // use the order in the dataLayers object to define the z-order
+    // Use the order in the dataLayers object to define the z-order
     dataLayers.forEach(function (layerGroup) {
-        // check if the layer has been added to the map, if it hasn't then do nothing
         const hasLayers =
           layerGroup._layers && 
           Object.keys(layerGroup._layers).length > 0;
@@ -537,7 +533,7 @@ function fixZOrder(dataLayers) {
           hasLayers &&
           layerGroup._layers[Object.keys(layerGroup._layers)[0]]._path &&
           layerGroup._layers[Object.keys(layerGroup._layers)[0]]._path.parentNode;
-        // If the layers are set to be visible, bring them to the front
+        // If if the layer group has been added to the map, bring it to the front
         if (hasVisibleLayers) { layerGroup.bringToFront() };
     });
 }

--- a/script.js
+++ b/script.js
@@ -347,9 +347,8 @@ function handleData([
   map.on('overlayadd', function () {
     // Top of list is top layer
     fixZOrder([
-      rentStrikes, 
       localities, 
-      states
+      states,
     ]);
   });
 
@@ -525,15 +524,10 @@ function fixZOrder(dataLayers) {
   dataLayers
     // Reverse layers so that top of list is the top layer
     .reverse()
-    .forEach(function (layerGroup) {
-      const hasLayers =
-        layerGroup._layers != null && 
-        Object.keys(layerGroup._layers).length > 0;
-      const hasVisibleLayers =
-        hasLayers &&
-        Object.values(layerGroup._layers)[0]._path != null &&
-        Object.values(layerGroup._layers)[0]._path.parentNode != null;
+    .forEach(function (layerGroup) { 
       // If if the layer group has been added to the map, bring it to the front
-      if (hasVisibleLayers) { layerGroup.bringToFront() };
+      if (map.hasLayer(layerGroup)) {
+        layerGroup.bringToFront();
+      }
     });
 }

--- a/script.js
+++ b/script.js
@@ -343,11 +343,12 @@ function handleData([
     .addOverlay(states, "States")
     .addOverlay(rentStrikes, "Rent Strikes");
 
-   const dataLayersOrder = {
+  // Order of how layers are displayed. Last is on top
+  const dataLayersOrder = [
      states,
      localities,
      rentStrikes,
-   };
+  ];
 
    // Apply correct relative order of layers when adding from control
    map.on('overlayadd', function () {
@@ -527,14 +528,15 @@ function handleRentStrikeLayer(geoJson) {
  **/
 function fixZOrder(dataLayers) {
     // use the order in the dataLayers object to define the z-order
-    Object.keys(dataLayers).forEach(function (key) {
+    dataLayers.forEach(function (layerGroup) {
         // check if the layer has been added to the map, if it hasn't then do nothing
-        const layerGroup = dataLayers[key];
         const hasLayers =
-          layerGroup._layers && Object.keys(layerGroup._layers).length > 0;
+          layerGroup._layers && 
+          Object.keys(layerGroup._layers).length > 0;
         const hasVisibleLayers =
           hasLayers &&
-          layerGroup._layers[Object.keys(layerGroup._layers)[0]]._path;
+          layerGroup._layers[Object.keys(layerGroup._layers)[0]]._path &&
+          layerGroup._layers[Object.keys(layerGroup._layers)[0]]._path.parentNode;
         // If the layers are set to be visible, bring them to the front
         if (hasVisibleLayers) { layerGroup.bringToFront() };
     });

--- a/script.js
+++ b/script.js
@@ -527,12 +527,12 @@ function fixZOrder(dataLayers) {
   // Use the order in the dataLayers object to define the z-order
   dataLayers.forEach(function (layerGroup) {
     const hasLayers =
-      layerGroup._layers && 
+      layerGroup._layers != null && 
       Object.keys(layerGroup._layers).length > 0;
     const hasVisibleLayers =
       hasLayers &&
-      layerGroup._layers[Object.keys(layerGroup._layers)[0]]._path &&
-      layerGroup._layers[Object.keys(layerGroup._layers)[0]]._path.parentNode;
+      layerGroup._layers[Object.keys(layerGroup._layers)[0]]._path != null &&
+      layerGroup._layers[Object.keys(layerGroup._layers)[0]]._path.parentNode != null;
     // If if the layer group has been added to the map, bring it to the front
     if (hasVisibleLayers) { layerGroup.bringToFront() };
   });


### PR DESCRIPTION
Resolves issue: https://github.com/antievictionmappingproject/covid-19-map/issues/18

Changes:
* Creates function for correcting the z order of layers, sorting what is vissible by the defined order
* Sets event listener to correct z order when layers are added