### PR TITLE
Fix info container hight for different screen sizes

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -31,6 +31,7 @@ body {
 
 header {
   width: 30%;
+  max-height: 90%;
   position: absolute;
   top: 12px;
   left: 12px;
@@ -40,10 +41,19 @@ header {
   border-radius: 5px;
   background-clip: padding-box;
   z-index: 500;
+
+  display: flex;
+  flex-direction: column;
 }
 
 header > h1 {
   margin: 0 0 1.2rem 0;
+}
+
+details {
+  flex-grow: 1;
+  flex-shrink: 1;
+  overflow-y: scroll;
 }
 
 details > summary {
@@ -72,6 +82,7 @@ details p:last-of-type {
     left: 0;
     width: 70%;
     margin: 1rem;
+    max-height: 400px;
   }
 
   header > h1 {
@@ -226,11 +237,5 @@ a.aemp-infowindow-close {
     margin: 0;
     width: 100%;
     height: 50%;
-  }
-
-  .title-content-wrapper {
-   
-    max-height: 250px;
-    overflow-y: auto;
   }
 }


### PR DESCRIPTION
Resolves: https://github.com/antievictionmappingproject/covid-19-map/issues/38

Changes:
* Max height on the info container on all screen sizes is 90%. Now it will not exceed the hight of the parent.
* Info container as flex box with column direction, in order to enforce correct overflow and shrink behaviour as a result of parent size
* Details section of info container can shrink and grow, and overflows with scroll if content exceeds parent container
* Sets max height of info container on mobile, not max height of the details. This is more consistent because before the height of the title could change and still lead to overflow out of map container.

Compromise:
* I haven't been able to get the details component to work such that only the details text scrolls and the summary title stays fixed. Currently the details text and summary title scrolls.