### PR TITLE
#38: fix header content overflow

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -31,17 +31,26 @@ body {
 
 header {
   width: 30%;
-  position: fixed;
+  position: absolute;
   top: 12px;
   left: 12px;
-  max-height: calc(100vh - 24px);
-  overflow-y: auto;
   padding: 12px;
   background: #fff;
   border: 2px solid rgba(0, 0, 0, 0.2);
   border-radius: 5px;
   background-clip: padding-box;
   z-index: 500;
+}
+
+.title-content-wrapper {
+  max-height: 50vh; 
+  overflow-y: auto;
+}
+
+@media (max-width: 640px) {
+  .title-content-wrapper {
+    max-height: 250px;
+  }
 }
 
 header > h1 {

--- a/styles.css
+++ b/styles.css
@@ -31,9 +31,11 @@ body {
 
 header {
   width: 30%;
-  position: absolute;
+  position: fixed;
   top: 12px;
   left: 12px;
+  max-height: calc(100vh - 24px);
+  overflow-y: auto;
   padding: 12px;
   background: #fff;
   border: 2px solid rgba(0, 0, 0, 0.2);

--- a/styles.css
+++ b/styles.css
@@ -229,10 +229,4 @@ a.aemp-infowindow-close {
     width: 100%;
     height: 50%;
   }
-
-  .title-content-wrapper {
-   
-    max-height: 250px;
-    overflow-y: auto;
-  }
 }


### PR DESCRIPTION
- Set header position to fixed, and control height through calc'd max-height.
- Set header overflow-y: auto.
- Remove height limitations from title-content-wrapper since it's height is now limitted by header.