### PR TITLE
Set maxBounds and minZoom

### DIFF
--- a/script.js
+++ b/script.js
@@ -39,12 +39,12 @@ const cartoStatesURI = createStatesCartoURI();
 
 // options for configuring the Leaflet map
 // don't add the default zoom ui and attribution as they're customized first then added layer
-const mapOptions = { 
-  zoomControl: false, 
+const mapOptions = {
+  zoomControl: false,
   attributionControl: false,
   maxBounds: [
-    [-90, -190],
-    [90, 200]
+    [-85.05, -190], // lower left
+    [85.05, 200] // upper right
   ]
 };
 
@@ -252,13 +252,13 @@ L.tileLayer(
  *****************************************/
 
 function createCountiesCartoURI() {
-  const query = `SELECT 
-  c.the_geom, c.county as municipality, c.state as state_name, m.policy_type, m.policy_summary, m.link, 
+  const query = `SELECT
+  c.the_geom, c.county as municipality, c.state as state_name, m.policy_type, m.policy_summary, m.link,
   CASE m.passed WHEN true THEN 'Yes' ELSE 'No' END as passed
-  FROM us_county_boundaries c 
+  FROM us_county_boundaries c
   JOIN ${cartoSheetSyncTable} m
-  ON ST_Intersects(c.the_geom, m.the_geom) 
-  WHERE m.the_geom IS NOT NULL 
+  ON ST_Intersects(c.the_geom, m.the_geom)
+  WHERE m.the_geom IS NOT NULL
   AND m.admin_scale = 'County'
   OR m.admin_scale = 'City and County'`; // how should we handle cases with city and county?
 
@@ -266,12 +266,12 @@ function createCountiesCartoURI() {
 }
 
 function createStatesCartoURI() {
-  const query = `SELECT 
-  s.the_geom, s.state_name as municipality, m.policy_type, m.policy_summary, m.link, 
+  const query = `SELECT
+  s.the_geom, s.state_name as municipality, m.policy_type, m.policy_summary, m.link,
   CASE m.passed WHEN true THEN 'Yes' ELSE 'No' END as passed
   FROM state_5m s
   INNER JOIN ${cartoSheetSyncTable} m
-  ON s.state_name = m.state  
+  ON s.state_name = m.state
   AND m.admin_scale = 'State'`;
 
   return `https://ampitup.carto.com/api/v2/sql?q=${query}&format=geojson`;

--- a/script.js
+++ b/script.js
@@ -39,7 +39,14 @@ const cartoStatesURI = createStatesCartoURI();
 
 // options for configuring the Leaflet map
 // don't add the default zoom ui and attribution as they're customized first then added layer
-const mapOptions = { zoomControl: false, attributionControl: false };
+const mapOptions = { 
+  zoomControl: false, 
+  attributionControl: false,
+  maxBounds: [
+    [-90, -190],
+    [90, 200]
+  ]
+};
 
 // global map layer styling variables
 const strokeWeight = 1.5;
@@ -235,6 +242,7 @@ const rentStrikeInfowindowTemplate = document.getElementById(
 L.tileLayer(
   "https://a.basemaps.cartocdn.com/rastertiles/light_all/{z}/{x}/{y}@2x.png",
   {
+    minZoom: 3,
     maxZoom: 18
   }
 ).addTo(map);


### PR DESCRIPTION
Resolves: https://github.com/antievictionmappingproject/covid-19-map/issues/46

The maximum bounds applied on the longitude are slightly bigger than the size of one earth. This is so that places near the edge are not displayed too close to the edge. 

Here is a photo of the minimum zoom at the farthest east one can go. New Zealand is not too close to the edge
![minzoomfarwest](https://user-images.githubusercontent.com/41007222/80008126-94524780-84c7-11ea-8c26-018210e5b689.png)

And here's a photo of minimum zoom the farthest west one can go. Hawaii is inside the bounds nicely and New Zealand isn't too in the shot
![maxzoom](https://user-images.githubusercontent.com/41007222/80010105-38d58900-84ca-11ea-8c4c-a6fdca50abcb.png)
