### PR TITLE
Add global data to the map

### DIFF
--- a/index.html
+++ b/index.html
@@ -158,6 +158,44 @@
       </div>
     </script>
 
+    <script id="aemp-infowindow-template-nation" type="x-tmpl-mustache">
+      <div class="aemp-infowindow">
+        <a class="aemp-infowindow-close" href="#close" onClick="closeInfo()">×</a>
+        <div>
+          <p class="infowindow-title">
+            <strong>Emergency Tenant Protections</strong>
+          </p>
+        </div>
+        <div>
+          <p>
+            <strong>{{jurisdictionType}}: </strong>{{jurisdictionName}}
+          </p>
+        </div>
+        <div>
+          <p><strong>Policy strength: </strong>{{policyStrength}}</p>
+        </div>
+        <div>
+          <p><strong>Policy Summary:</strong></p>
+          <p>{{policy_summary}}</p>
+        </div>
+        {{#start}}
+        <div>
+          <p><strong>Effective: </strong>{{start}}</p>
+        </div>
+        {{/start}}
+        {{#_end}}
+        <div>
+          <p><strong>Ends: </strong>{{_end}}</p>
+        </div>
+        {{/_end}}
+        {{#link}}
+        <div>
+          <p><a target="_blank" href="{{link}}" rel="noopener noreferrer">View more info.</a></p>
+        </div>
+        {{/link}}
+      </div>
+    </script>
+
     <script id="aemp-rentstrike-infowindow-template" type="x-tmpl-mustache">
       <div class="aemp-infowindow">
         <a class="aemp-infowindow-close" href="#close" onClick="closeInfo()">×</a>

--- a/index.html
+++ b/index.html
@@ -106,7 +106,7 @@
       <div class="popup-container locality-popup-container">
         <div>
           <p class="popup-title">
-            <strong>{{jurisdictionName}}</strong>
+            <strong>{{popupName}}</strong>
           </p>
         </div>
       </div>

--- a/index.html
+++ b/index.html
@@ -172,11 +172,11 @@
           </p>
         </div>
         <div>
-          <p><strong>Policy strength: </strong>{{policyStrength}}</p>
-        </div>
-        <div>
           <p><strong>Policy Summary:</strong></p>
           <p>{{policy_summary}}</p>
+        </div>
+        <div>
+          <p><strong>Has It Passed Yet? </strong>{{passedText}}</p>
         </div>
         {{#start}}
         <div>

--- a/index.html
+++ b/index.html
@@ -106,7 +106,7 @@
       <div class="popup-container locality-popup-container">
         <div>
           <p class="popup-title">
-            <strong>{{municipality}}</strong>
+            <strong>{{jurisdictionName}}</strong>
           </p>
         </div>
       </div>
@@ -130,7 +130,7 @@
         </div>
         <div>
           <p>
-            <strong>Municipality: </strong>{{municipality}}
+            <strong>{{jurisdictionType}}: </strong>{{jurisdictionName}}
           </p>
         </div>
         <div>

--- a/script.js
+++ b/script.js
@@ -32,6 +32,7 @@ const cartoSheetSyncTable =
 // (all in AEMP CARTO acct)
 const cartoCountiesURI = createCountiesCartoURI();
 const cartoStatesURI = createStatesCartoURI();
+// const cartoNationsURI = createNationsCartoURI();
 
 /******************************************
  * MAP SETUP & MAP CONTROLS
@@ -267,15 +268,30 @@ function createCountiesCartoURI() {
 
 function createStatesCartoURI() {
   const query = `SELECT
-  s.the_geom, s.state_name as municipality, m.policy_type, m.policy_summary, m.link,
+  s.the_geom, s.name as municipality, m.policy_type, m.policy_summary, m.link,
   CASE m.passed WHEN true THEN 'Yes' ELSE 'No' END as passed
-  FROM state_5m s
+  FROM public.states_and_provinces_global s
   INNER JOIN ${cartoSheetSyncTable} m
-  ON s.state_name = m.state
+  ON s.name = m.state
   AND m.admin_scale = 'State'`;
 
   return `https://ampitup.carto.com/api/v2/sql?q=${query}&format=geojson`;
 }
+
+function createNationsCartoURI() {
+  const query = `SELECT
+  c.name, c.the_geom, c.iso_a3 
+  FROM public.countries c
+  INNER JOIN ${cartoSheetSyncTable} m
+  ON m.admin_scale = 'Country'
+  AND c.name = m.Country`;
+
+  return `https://ampitup.carto.com/api/v2/sql?q=${query}&format=geojson`;
+}
+
+Promise.resolve(fetch(createStatesCartoURI())).then(res =>
+  Promise.resolve(res.json()).then(geojson => console.log(geojson)),
+);
 
 /******************************************
  * FETCH DATA SOURCES
@@ -298,6 +314,10 @@ Promise.all([
     if (!res.ok) throw Error("Unable to fetch counties geojson");
     return res.json();
   })
+  // fetch(cartoCountiesURI).then(res => {
+  //   if (!res.ok) throw Error("Unable to fetch counties geojson");
+  //   return res.json();
+  // })
 ])
   .then(handleData)
   .catch(error => console.log(error));

--- a/script.js
+++ b/script.js
@@ -67,7 +67,7 @@ let mapConfig = {
   lat: 40.67,
   lng: -97.23,
   z: initialMapZoom,
-  nations: true,
+  nations: false,
   states: true,
   cities: true,
   counties: true,
@@ -417,6 +417,10 @@ function handleData([
 
   // if any layers in the map config are set to false,
   // remove them from the map
+  if (!mapConfig.nations) {
+    map.removeLayer(nations);
+  }
+
   if (!mapConfig.states) {
     map.removeLayer(states);
   }
@@ -437,6 +441,19 @@ function handleData([
 /******************************************
  * HANDLE ADDING MAP LAYERS
  *****************************************/
+
+// Styles
+const scoreFillColors = {
+  '1': '#2ca25f',
+  '2': '#99d8c9',
+  '3': '#e5f5f9',
+};
+
+const scoreDescription = {
+  '1': 'Many protections in place',
+  '2': 'Some protections in place',
+  '3': 'Few protections in place',
+};
 
 // Ensures that map overlay pane layers are displayed in the correct Z-Order
 function fixZOrder(dataLayers) {
@@ -658,18 +675,6 @@ function handleRentStrikeLayer(geoJson) {
   return rentStrikeLayerMarkers;
 }
 
-const scoreFillColors = {
-  '1': '#2ca25f',
-  '2': '#99d8c9',
-  '3': '#e5f5f9',
-};
-
-const scoreDescription = {
-  '1': 'Many protections in place',
-  '2': 'Some protections in place',
-  '3': 'Few protections in place',
-};
-
 // Do not add nations to map at start
 function handleNationsLayer(geojson) {
   // Scores are bound to range prop of each feature
@@ -707,6 +712,8 @@ function handleNationsLayer(geojson) {
     ).innerHTML = renderedInfo;
     return Mustache.render(popupTemplate, props);
   });
+
+  map.addLayer(nationsLayer);
 
   return nationsLayer;
 }

--- a/script.js
+++ b/script.js
@@ -431,6 +431,15 @@ function handleData([
  * HANDLE ADDING MAP LAYERS
  *****************************************/
 
+// Ensures that map overlay pane layers are displayed in the correct Z-Order
+function fixZOrder(dataLayers) {
+  dataLayers.forEach(function (layerGroup) {
+    if (map.hasLayer(layerGroup)) {
+      layerGroup.bringToBack();
+    }
+  });
+}
+
 function handleCitiesLayer(geojson) {
   // styling for the cities layer: style cities conditionally according to a presence of a moratorium
   const pointToLayer = (feature, latlng) => {
@@ -617,15 +626,6 @@ function handleRentStrikeLayer(geoJson) {
   map.addLayer(rentStrikeLayerMarkers);
 
   return rentStrikeLayerMarkers;
-}
-
-// Ensures that map overlay pane layers are displayed in the correct Z-Order
-function fixZOrder(dataLayers) {
-  dataLayers.forEach(function (layerGroup) {
-    if (map.hasLayer(layerGroup)) {
-      layerGroup.bringToBack();
-    }
-  });
 }
 
 function handleNationsLayer(geojson) {

--- a/script.js
+++ b/script.js
@@ -32,7 +32,7 @@ const cartoSheetSyncTable =
 // (all in AEMP CARTO acct)
 const cartoCountiesURI = createCountiesCartoURI();
 const cartoStatesURI = createStatesCartoURI();
-// const cartoNationsURI = createNationsCartoURI();
+const cartoNationsURI = createNationsCartoURI();
 
 /******************************************
  * MAP SETUP & MAP CONTROLS
@@ -280,18 +280,18 @@ function createStatesCartoURI() {
 
 function createNationsCartoURI() {
   const query = `SELECT
-  c.name, c.the_geom, c.iso_a3 
+  c.the_geom, c.iso_a3, m.ISO, c.name as country, m.range, m.passed, m.policy_type, m.policy_summary
   FROM public.countries c
   INNER JOIN ${cartoSheetSyncTable} m
   ON m.admin_scale = 'Country'
-  AND c.name = m.Country`;
+  AND c.iso_a3 = m.ISO`;
 
   return `https://ampitup.carto.com/api/v2/sql?q=${query}&format=geojson`;
 }
 
-Promise.resolve(fetch(createStatesCartoURI())).then(res =>
-  Promise.resolve(res.json()).then(geojson => console.log(geojson)),
-);
+// Promise.resolve(fetch(createNationsCartoURI())).then(res =>
+//   Promise.resolve(res.json()).then(geojson => console.log(geojson)),
+// );
 
 /******************************************
  * FETCH DATA SOURCES
@@ -313,11 +313,11 @@ Promise.all([
   fetch(cartoCountiesURI).then(res => {
     if (!res.ok) throw Error("Unable to fetch counties geojson");
     return res.json();
+  }),
+  fetch(cartoNationsURI).then(res => {
+    if (!res.ok) throw Error("Unable to fetch counties geojson");
+    return res.json();
   })
-  // fetch(cartoCountiesURI).then(res => {
-  //   if (!res.ok) throw Error("Unable to fetch counties geojson");
-  //   return res.json();
-  // })
 ])
   .then(handleData)
   .catch(error => console.log(error));
@@ -330,7 +330,8 @@ function handleData([
   moratoriumSheetsText,
   rentStrikeSheetsText,
   statesGeoJson,
-  countiesGeoJson
+  countiesGeoJson,
+  nationsGeoJson
 ]) {
   const moratoriumRows = d3
     .csvParse(moratoriumSheetsText, d3.autoType)
@@ -387,6 +388,7 @@ function handleData([
 
   // add the states, cities, counties, and rentstrikes layers to the map
   // and save the layers output
+  const nations = handleNationsLayer(nationsGeoJson);
   const states = handleStatesLayer(statesGeoJson);
   const counties = handleCountiesLayer(countiesGeoJson);
   const cities = handleCitiesLayer(citiesGeoJson);
@@ -397,12 +399,13 @@ function handleData([
     .addOverlay(rentStrikes, "Rent Strikes")
     .addOverlay(cities, "Cities")
     .addOverlay(counties, "Counties")
-    .addOverlay(states, "States");
+    .addOverlay(states, "States")
+    .addOverlay(nations, "Nations");
 
   // Apply correct relative order of layers when adding from control.
   map.on("overlayadd", function () {
     // Top of list is top layer
-    fixZOrder([cities, counties, states]);
+    fixZOrder([cities, counties, states, nations]);
   });
 
   // if any layers in the map config are set to false,
@@ -623,4 +626,51 @@ function fixZOrder(dataLayers) {
       layerGroup.bringToBack();
     }
   });
+}
+
+function handleNationsLayer(geojson) {
+  // styling for the nations layer: style states conditionally according to a presence of a moratorium
+  const layerOptions = {
+    style: feature => {
+      // style states based on whether their moratorium has passed
+      if (feature.properties.passed === 'Yes') {
+        return {
+          color: '#4dac26',
+          fillColor: '#b8e186',
+          fillOpacity: fillOpacity,
+          weight: strokeWeight,
+        };
+      } else if (feature.properties.passed === 'No') {
+        return {
+          color: '#d01c8b',
+          fillColor: '#f1b6da',
+          fillOpacity: fillOpacity,
+          weight: strokeWeight,
+        };
+      } else {
+        return {
+          stroke: false,
+          fill: false,
+        };
+      }
+    },
+  };
+
+  // Create the Leaflet layer for the states data
+  const nationsLayer = L.geoJson(geojson, layerOptions);
+
+  nationsLayer.bindPopup(function (layer) {
+    const renderedInfo = Mustache.render(
+      infowindowTemplate,
+      layer.feature.properties,
+    );
+    document.getElementById(
+      'aemp-infowindow-container',
+    ).innerHTML = renderedInfo;
+    return Mustache.render(popupTemplate, layer.feature.properties);
+  });
+
+  nationsLayer.addTo(map);
+
+  return nationsLayer;
 }

--- a/script.js
+++ b/script.js
@@ -671,21 +671,16 @@ const scoreDescription = {
   '3': 'Strong protection'
 }
 
-function polygonColorsByScore(score) {
-  return {
-    // Return fill color from score, or grey
-    fillColor: scoreFillColors[score] || '#f0f0f0',
-    color: '#000'
-  };
-}
-
 function handleNationsLayer(geojson) {
   // Scores are bound to range prop of each feature
   const layerOptions = {
     style: feature => {
-      const colorsObject = polygonColorsByScore(feature.properties.range)
+      const score = feature.properties.range
       return {
-        ...colorsObject,
+        // Get colour from score
+        fillColor: scoreFillColors[score],
+        color: '#333',
+        opacity: 0.7,
         fillOpacity: 0.7,
         weight: 1.2,
       };

--- a/script.js
+++ b/script.js
@@ -279,12 +279,12 @@ function createStatesCartoURI() {
 }
 
 function createNationsCartoURI() {
-  const query = `SELECT
-  c.the_geom, c.iso_a3, m.ISO, c.name as country, m.range, m.passed, m.policy_type, m.policy_summary
-  FROM public.countries c
-  INNER JOIN ${cartoSheetSyncTable} m
-  ON m.admin_scale = 'Country'
-  AND c.iso_a3 = m.ISO`;
+  const query = `SELECT c.the_geom, c.iso_a3, c.name_en, 
+  m.policy_type, m.policy_summary, m.link, m.range, m.policy_type, m.start, m._end, m.link 
+  FROM countries c 
+  INNER JOIN ${cartoSheetSyncTable} m 
+  ON c.iso_a3 = m.iso 
+  AND m.admin_scale = 'Country'`;
 
   return `https://ampitup.carto.com/api/v2/sql?q=${query}&format=geojson`;
 }
@@ -632,27 +632,13 @@ function handleNationsLayer(geojson) {
   // styling for the nations layer: style states conditionally according to a presence of a moratorium
   const layerOptions = {
     style: feature => {
-      // style states based on whether their moratorium has passed
-      if (feature.properties.passed === 'Yes') {
-        return {
-          color: '#4dac26',
-          fillColor: '#b8e186',
-          fillOpacity: fillOpacity,
-          weight: strokeWeight,
-        };
-      } else if (feature.properties.passed === 'No') {
-        return {
-          color: '#d01c8b',
-          fillColor: '#f1b6da',
-          fillOpacity: fillOpacity,
-          weight: strokeWeight,
-        };
-      } else {
-        return {
-          stroke: false,
-          fill: false,
-        };
-      }
+    // style states based on whether their moratorium has passed
+      return {
+        color: '#4dac26',
+        fillColor: '#b8e186',
+        fillOpacity: fillOpacity,
+        weight: strokeWeight,
+      };
     },
   };
 

--- a/script.js
+++ b/script.js
@@ -279,7 +279,7 @@ function createCountiesCartoURI() {
 
 function createStatesCartoURI() {
   const query = `SELECT
-  s.the_geom, s.name, m.policy_type, m.policy_summary, m.link,
+  s.the_geom, s.name, m.iso, m.policy_type, m.policy_summary, m.link,
   CASE m.passed WHEN true THEN 'Yes' ELSE 'No' END as passed
   FROM public.states_and_provinces_global s
   INNER JOIN ${cartoSheetSyncTable} m
@@ -299,10 +299,6 @@ function createNationsCartoURI() {
 
   return `https://ampitup.carto.com/api/v2/sql?q=${query}&format=geojson`;
 }
-
-// Promise.resolve(fetch(createNationsCartoURI())).then(res =>
-//   Promise.resolve(res.json()).then(geojson => console.log(geojson)),
-// );
 
 /******************************************
  * FETCH DATA SOURCES
@@ -485,10 +481,10 @@ function handleCitiesLayer(geojson) {
 
     // Render the template with all of the properties. Mustache ignores properties
     // that aren't used in the template, so this is fine.
-    const { municipality, state, Country } = layer.feature.properties; 
+    const { municipality, state, Country: country } = layer.feature.properties; 
     const props = {
-      // Build city name with state and country
-      jurisdictionName: `${municipality}, ${state ? `${state} , ${Country}` : `${Country}`}`,
+      // Build city name with state and country if supplied
+      jurisdictionName: `${municipality}${state ? `, ${state}`: ''}${country ? `, ${country}` : ''}`,
       jurisdictionType: 'City',
       ...layer.feature.properties,
     };
@@ -603,7 +599,7 @@ function handleStatesLayer(geojson) {
     return Mustache.render(popupTemplate, props);
   });
 
-  // statesLayer.addTo(map);
+  statesLayer.addTo(map);
 
   return statesLayer;
 }
@@ -660,28 +656,29 @@ function handleRentStrikeLayer(geoJson) {
 }
 
 const scoreFillColors = {
-  '1': '#e5f5f9',
+  '1': '#2ca25f',
   '2': '#99d8c9',
-  '3': '#2ca25f'
+  '3': '#e5f5f9',
 };
 
 const scoreDescription = {
-  '1': 'Low protection',
-  '2': 'Medium protection',
-  '3': 'Strong protection'
-}
+  '1': 'Many protections in place',
+  '2': 'Some protections in place',
+  '3': 'Few protections in place',
+};
 
+// Do not add nations to map at start
 function handleNationsLayer(geojson) {
   // Scores are bound to range prop of each feature
   const layerOptions = {
     style: feature => {
       const score = feature.properties.range
       return {
-        // Get colour from score
-        fillColor: scoreFillColors[score],
+        // Get color from score
+        fillColor: scoreFillColors[score] || '', // fallback color
+        fillOpacity: 0.7,
         color: '#333',
         opacity: 0.7,
-        fillOpacity: 0.7,
         weight: 1.2,
       };
     },
@@ -707,8 +704,6 @@ function handleNationsLayer(geojson) {
     ).innerHTML = renderedInfo;
     return Mustache.render(popupTemplate, props);
   });
-
-  nationsLayer.addTo(map);
 
   return nationsLayer;
 }

--- a/script.js
+++ b/script.js
@@ -470,18 +470,27 @@ function handleCitiesLayer(geojson) {
 
   // Add popups to the layer
   citiesLayer.bindPopup(function (layer) {
+    console.log(layer.feature)
     // This function is called whenever a feature on the layer is clicked
 
     // Render the template with all of the properties. Mustache ignores properties
     // that aren't used in the template, so this is fine.
+    const { municipality, state, Country } = layer.feature.properties; 
+    const props = {
+      // Build city name with state and country
+      jurisdictionName: `${municipality}, ${state ? `${state} , ${Country}` : `${Country}`}`,
+      jurisdictionType: 'City',
+      ...layer.feature.properties,
+    };
+
     const renderedInfo = Mustache.render(
       infowindowTemplate,
-      layer.feature.properties
+      props
     );
     document.getElementById(
       "aemp-infowindow-container"
     ).innerHTML = renderedInfo;
-    return Mustache.render(popupTemplate, layer.feature.properties);
+    return Mustache.render(popupTemplate, { ...props, jurisdictionName: municipality });
   });
 
   // Add data to the map
@@ -516,14 +525,19 @@ function handleCountiesLayer(geojson) {
   const countiesLayer = L.geoJson(geojson, layerOptions);
 
   countiesLayer.bindPopup(function (layer) {
+    const props = {
+      jurisdictionName: layer.feature.properties.municipality,
+      jurisdictionType: 'County',
+      ...layer.feature.properties,
+    };
     const renderedInfo = Mustache.render(
       infowindowTemplate,
-      layer.feature.properties
+      props
     );
     document.getElementById(
       "aemp-infowindow-container"
     ).innerHTML = renderedInfo;
-    return Mustache.render(popupTemplate, layer.feature.properties);
+    return Mustache.render(popupTemplate, props);
   });
 
   countiesLayer.addTo(map);
@@ -562,14 +576,19 @@ function handleStatesLayer(geojson) {
   const statesLayer = L.geoJson(geojson, layerOptions);
 
   statesLayer.bindPopup(function (layer) {
+    const props = {
+      jurisdictionName: layer.feature.properties.municipality,
+      jurisdictionType: 'State/Province',
+      ...layer.feature.properties,
+    };
     const renderedInfo = Mustache.render(
       infowindowTemplate,
-      layer.feature.properties
+      props
     );
     document.getElementById(
       "aemp-infowindow-container"
     ).innerHTML = renderedInfo;
-    return Mustache.render(popupTemplate, layer.feature.properties);
+    return Mustache.render(popupTemplate, props);
   });
 
   // statesLayer.addTo(map);
@@ -632,7 +651,7 @@ function handleNationsLayer(geojson) {
   // styling for the nations layer: style states conditionally according to a presence of a moratorium
   const layerOptions = {
     style: feature => {
-    // style states based on whether their moratorium has passed
+    // style nations based on their rating
       return {
         color: '#4dac26',
         fillColor: '#b8e186',
@@ -642,14 +661,14 @@ function handleNationsLayer(geojson) {
     },
   };
 
-  // Create the Leaflet layer for the states data
+  // Create the Leaflet layer for the nations data
   const nationsLayer = L.geoJson(geojson, layerOptions);
-  
   
   nationsLayer.bindPopup(function (layer) {
     const props = {
-      municipality: layer.feature.properties.name_en,
-      ...layer.feature.properties
+      jurisdictionName: layer.feature.properties.name_en,
+      jurisdictionType: 'Country',
+      ...layer.feature.properties,
     };
     const renderedInfo = Mustache.render(
       infowindowTemplate,

--- a/script.js
+++ b/script.js
@@ -678,7 +678,7 @@ function handleNationsLayer(geojson) {
       const score = feature.properties.range
       return {
         // Get color from score
-        fillColor: scoreFillColors[score] || '', // fallback color
+        fillColor: scoreFillColors[score] || '#808080', // fallback color
         fillOpacity: 0.7,
         color: '#333',
         opacity: 0.7,

--- a/script.js
+++ b/script.js
@@ -572,7 +572,7 @@ function handleStatesLayer(geojson) {
     return Mustache.render(popupTemplate, layer.feature.properties);
   });
 
-  statesLayer.addTo(map);
+  // statesLayer.addTo(map);
 
   return statesLayer;
 }
@@ -644,16 +644,21 @@ function handleNationsLayer(geojson) {
 
   // Create the Leaflet layer for the states data
   const nationsLayer = L.geoJson(geojson, layerOptions);
-
+  
+  
   nationsLayer.bindPopup(function (layer) {
+    const props = {
+      municipality: layer.feature.properties.name_en,
+      ...layer.feature.properties
+    };
     const renderedInfo = Mustache.render(
       infowindowTemplate,
-      layer.feature.properties,
+      props,
     );
     document.getElementById(
       'aemp-infowindow-container',
     ).innerHTML = renderedInfo;
-    return Mustache.render(popupTemplate, layer.feature.properties);
+    return Mustache.render(popupTemplate, props);
   });
 
   nationsLayer.addTo(map);

--- a/script.js
+++ b/script.js
@@ -232,6 +232,8 @@ const layersControl = L.control
 const popupTemplate = document.querySelector(".popup-template").innerHTML;
 const infowindowTemplate = document.getElementById("aemp-infowindow-template")
   .innerHTML;
+const nationInfowindowTemplate = document.getElementById('aemp-infowindow-template-nation')
+  .innerHTML;
 
 const rentStrikePopupTemplate = document.querySelector(
   ".rentstrike-popup-template"
@@ -654,6 +656,12 @@ const scoreFillColors = {
   '3': '#2ca25f'
 };
 
+const scoreDescription = {
+  '1': 'Low protection',
+  '2': 'Medium protection',
+  '3': 'Strong protection'
+}
+
 function polygonColorsByScore(score) {
   return {
     // Return fill color from score, or grey
@@ -663,6 +671,7 @@ function polygonColorsByScore(score) {
 }
 
 function handleNationsLayer(geojson) {
+  // Scores are bound to range prop of each feature
   const layerOptions = {
     style: feature => {
       const colorsObject = polygonColorsByScore(feature.properties.range)
@@ -678,15 +687,15 @@ function handleNationsLayer(geojson) {
   const nationsLayer = L.geoJson(geojson, layerOptions);
   
   nationsLayer.bindPopup(function (layer) {
+    const { name_en, range } = layer.feature.properties;
     const props = {
-      jurisdictionName: layer.feature.properties.name_en,
+      jurisdictionName: name_en,
       jurisdictionType: 'Country',
-      // Placeholder, using 'passed' to send to label "has it passed"
-      passed: layer.feature.properties.range,
+      policyStrength: scoreDescription[range],
       ...layer.feature.properties,
     };
     const renderedInfo = Mustache.render(
-      infowindowTemplate,
+      nationInfowindowTemplate,
       props,
     );
     document.getElementById(

--- a/script.js
+++ b/script.js
@@ -648,16 +648,28 @@ function handleRentStrikeLayer(geoJson) {
   return rentStrikeLayerMarkers;
 }
 
+const scoreFillColors = {
+  '1': '#e5f5f9',
+  '2': '#99d8c9',
+  '3': '#2ca25f'
+};
+
+function polygonColorsByScore(score) {
+  return {
+    // Return fill color from score, or grey
+    fillColor: scoreFillColors[score] || '#f0f0f0',
+    color: '#000'
+  };
+}
+
 function handleNationsLayer(geojson) {
-  // styling for the nations layer: style states conditionally according to a presence of a moratorium
   const layerOptions = {
     style: feature => {
-    // style nations based on their rating
+      const colorsObject = polygonColorsByScore(feature.properties.range)
       return {
-        color: '#4dac26',
-        fillColor: '#b8e186',
-        fillOpacity: fillOpacity,
-        weight: strokeWeight,
+        ...colorsObject,
+        fillOpacity: 0.7,
+        weight: 1.2,
       };
     },
   };

--- a/script.js
+++ b/script.js
@@ -67,6 +67,7 @@ let mapConfig = {
   lat: 40.67,
   lng: -97.23,
   z: initialMapZoom,
+  nations: true,
   states: true,
   cities: true,
   counties: true,
@@ -126,6 +127,14 @@ function inputValues(hash) {
       mapConfig.states = false;
     }
   }
+
+   if (inputVals.nations !== undefined) {
+     if (inputVals.nations === 'true') {
+       mapConfig.nations = true;
+     } else if (inputVals.nations === 'false') {
+       mapConfig.nations = false;
+     }
+   }
 
   if (inputVals.rentstrike !== undefined) {
     if (inputVals.rentstrike === "true") {

--- a/script.js
+++ b/script.js
@@ -254,7 +254,7 @@ L.tileLayer(
 
 function createCountiesCartoURI() {
   const query = `SELECT
-  c.the_geom, c.county as municipality, c.state as state_name, m.policy_type, m.policy_summary, m.link,
+  c.the_geom, c.county, c.state, m.policy_type, m.policy_summary, m.link,
   CASE m.passed WHEN true THEN 'Yes' ELSE 'No' END as passed
   FROM us_county_boundaries c
   JOIN ${cartoSheetSyncTable} m
@@ -268,7 +268,7 @@ function createCountiesCartoURI() {
 
 function createStatesCartoURI() {
   const query = `SELECT
-  s.the_geom, s.name as municipality, m.policy_type, m.policy_summary, m.link,
+  s.the_geom, s.name, m.policy_type, m.policy_summary, m.link,
   CASE m.passed WHEN true THEN 'Yes' ELSE 'No' END as passed
   FROM public.states_and_provinces_global s
   INNER JOIN ${cartoSheetSyncTable} m
@@ -470,7 +470,6 @@ function handleCitiesLayer(geojson) {
 
   // Add popups to the layer
   citiesLayer.bindPopup(function (layer) {
-    console.log(layer.feature)
     // This function is called whenever a feature on the layer is clicked
 
     // Render the template with all of the properties. Mustache ignores properties
@@ -525,8 +524,10 @@ function handleCountiesLayer(geojson) {
   const countiesLayer = L.geoJson(geojson, layerOptions);
 
   countiesLayer.bindPopup(function (layer) {
+    const { county, state } = layer.feature.properties;
     const props = {
-      jurisdictionName: layer.feature.properties.municipality,
+      // Show county with state if state field is set
+      jurisdictionName: `${county}${state ? `, ${state}`: ''}`,
       jurisdictionType: 'County',
       ...layer.feature.properties,
     };
@@ -577,7 +578,7 @@ function handleStatesLayer(geojson) {
 
   statesLayer.bindPopup(function (layer) {
     const props = {
-      jurisdictionName: layer.feature.properties.municipality,
+      jurisdictionName: layer.feature.properties.name,
       jurisdictionType: 'State/Province',
       ...layer.feature.properties,
     };
@@ -668,6 +669,8 @@ function handleNationsLayer(geojson) {
     const props = {
       jurisdictionName: layer.feature.properties.name_en,
       jurisdictionType: 'Country',
+      // Placeholder, using 'passed' to send to label "has it passed"
+      passed: layer.feature.properties.range,
       ...layer.feature.properties,
     };
     const renderedInfo = Mustache.render(

--- a/script.js
+++ b/script.js
@@ -279,7 +279,7 @@ function createCountiesCartoURI() {
 
 function createStatesCartoURI() {
   const query = `SELECT
-  s.the_geom, s.name, m.iso, m.policy_type, m.policy_summary, m.link,
+  s.the_geom, s.name, s.admin, m.iso, m.policy_type, m.policy_summary, m.link,
   CASE m.passed WHEN true THEN 'Yes' ELSE 'No' END as passed
   FROM public.states_and_provinces_global s
   INNER JOIN ${cartoSheetSyncTable} m
@@ -481,10 +481,10 @@ function handleCitiesLayer(geojson) {
 
     // Render the template with all of the properties. Mustache ignores properties
     // that aren't used in the template, so this is fine.
-    const { municipality, state, Country: country } = layer.feature.properties; 
+    const { municipality, state, Country } = layer.feature.properties; 
     const props = {
       // Build city name with state and country if supplied
-      jurisdictionName: `${municipality}${state ? `, ${state}`: ''}${country ? `, ${country}` : ''}`,
+      jurisdictionName: `${municipality}${state ? `, ${state}`: ''}${Country ? `, ${Country}` : ''}`,
       jurisdictionType: 'City',
       ...layer.feature.properties,
     };
@@ -496,6 +496,7 @@ function handleCitiesLayer(geojson) {
     document.getElementById(
       "aemp-infowindow-container"
     ).innerHTML = renderedInfo;
+    // Override jurisdiction name for popup
     return Mustache.render(popupTemplate, { ...props, jurisdictionName: municipality });
   });
 
@@ -584,8 +585,9 @@ function handleStatesLayer(geojson) {
   const statesLayer = L.geoJson(geojson, layerOptions);
 
   statesLayer.bindPopup(function (layer) {
+    const { name, admin } = layer.feature.properties;
     const props = {
-      jurisdictionName: layer.feature.properties.name,
+      jurisdictionName: `${name}${admin ? `, ${admin}` : ''}`,
       jurisdictionType: 'State/Province',
       ...layer.feature.properties,
     };
@@ -596,7 +598,8 @@ function handleStatesLayer(geojson) {
     document.getElementById(
       "aemp-infowindow-container"
     ).innerHTML = renderedInfo;
-    return Mustache.render(popupTemplate, props);
+    // Overwrite jurisdiction name to remove country
+    return Mustache.render(popupTemplate, { ...props, jurisdictionName: name });
   });
 
   statesLayer.addTo(map);


### PR DESCRIPTION
- Update query for states layer to include global regions and provinces
- Add new query and layer for nations and add control for this layer to map.
- Set nations layer as off by default, and allow it to be set with url for iframe
- Mustache template for cities and states infowindow now takes jurisdictionName and jurisdictionLabel to build more clear text in the info window.
  - Logic for preparing props to send to templates is now in bindpopup method.
  - renaming the feature name prop to 'municipality' is no longer done in the query, instead it's renamed to 'jurisdictionName' inside each feature collections 'create layer' handler.
  - Names are now built with the region and the country when relevant, for more useful global names.
- New template created for nation infowindow, probably want to use this as the only info window template starting when we have all features with a ranking.

