### PR TITLE
hotfix: fixed missing polygons in nations layer

### DIFF
--- a/script.js
+++ b/script.js
@@ -291,11 +291,11 @@ function createStatesCartoURI() {
 }
 
 function createNationsCartoURI() {
-  const query = `SELECT c.the_geom, c.iso_a3, c.name_en, 
-  m.policy_type, m.policy_summary, m.link, m.policy_type, m.start, m._end, m.passed
-  FROM countries c 
-  INNER JOIN ${cartoSheetSyncTable} m 
-  ON c.iso_a3 = m.iso 
+  const query = `SELECT c.the_geom, c.adm0_a3, c.name_en,
+  m.policy_type, m.policy_summary, m.link, m.start, m._end, m.passed
+  FROM countries c
+  INNER JOIN ${cartoSheetSyncTable} m
+  ON c.adm0_a3 = m.iso
   AND m.admin_scale = 'Country'`;
 
   return `https://ampitup.carto.com/api/v2/sql?q=${query}&format=geojson`;

--- a/script.js
+++ b/script.js
@@ -254,7 +254,7 @@ const rentStrikeInfowindowTemplate = document.getElementById(
 L.tileLayer(
   "https://a.basemaps.cartocdn.com/rastertiles/light_all/{z}/{x}/{y}@2x.png",
   {
-    minZoom: 3,
+    minZoom: 1,
     maxZoom: 18
   }
 ).addTo(map);


### PR DESCRIPTION
TL,DR;

In our `countries` table on Carto, there are some countries missing 3 letter ISO codes in the `iso_a3` field. Using the `adm0_a3` field joins all countries from our current data correctly and is not missing codes for any country. Guess we missed this when creating the nations SQL query, oops!

I'm also sneaking in a commit here so that the map can be zoomed out to the whole world (zoom level 1) instead of constraining it to zoom level 3. This relates to #57 