### PR TITLE
Update dependencies in index.html

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -12,7 +12,7 @@
 
     <!-- Load Leaflet CSS -->
     <link
-      href="https://unpkg.com/leaflet@1.3.4/dist/leaflet.css"
+      href="https://unpkg.com/leaflet@1.6.0/dist/leaflet.css"
       rel="stylesheet"
     />
     <!-- Load the Marker Cluster CSS -->
@@ -202,7 +202,7 @@
     </script>
 
     <!-- Load Leaflet library -->
-    <script src="https://unpkg.com/leaflet@1.3.4/dist/leaflet.js"></script>
+    <script src="https://unpkg.com/leaflet@1.6.0/dist/leaflet.js"></script>
 
     <!-- Load Leaflet Marker Cluster plugin -->
     <script src="https://unpkg.com/leaflet.markercluster@1.4.1/dist/leaflet.markercluster-src.js"></script>

--- a/public/index.html
+++ b/public/index.html
@@ -207,13 +207,19 @@
     <!-- Load Leaflet Marker Cluster plugin -->
     <script src="https://unpkg.com/leaflet.markercluster@1.4.1/dist/leaflet.markercluster-src.js"></script>
 
+    <!-- Load Promises polyfill -->
+    <script src="https://cdn.jsdelivr.net/npm/promise-polyfill@8/dist/polyfill.min.js"></script>
+
+    <!-- Load Fetch polyfill -->
+    <script src="https://cdn.jsdelivr.net/npm/whatwg-fetch@2.0.4/fetch.js"></script>
+
     <!-- <details> element polyfill for IE -->
     <script src="//cdn.jsdelivr.net/npm/details-polyfill@1/index.min.js"></script>
 
     <!-- import the Mustache library -->
     <script src="https://cdnjs.cloudflare.com/ajax/libs/mustache.js/3.0.0/mustache.min.js"></script>
 
-    <!-- Load d3-tsv & d3-dispatch -->
+    <!-- Load d3-tsv -->
     <script src="https://d3js.org/d3-dsv.v1.min.js"></script>
     <script src="https://d3js.org/d3-dispatch.v1.min.js"></script>
   </body>

--- a/public/index.html
+++ b/public/index.html
@@ -208,7 +208,7 @@
     <script src="https://unpkg.com/leaflet.markercluster@1.4.1/dist/leaflet.markercluster-src.js"></script>
 
     <!-- Load Fetch polyfill -->
-    <script src="https://cdn.jsdelivr.net/npm/whatwg-fetch@2.0.4/fetch.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/whatwg-fetch@3/fetch.js"></script>
 
     <!-- <details> element polyfill for IE -->
     <script src="//cdn.jsdelivr.net/npm/details-polyfill@1/index.min.js"></script>

--- a/public/index.html
+++ b/public/index.html
@@ -214,7 +214,7 @@
     <script src="//cdn.jsdelivr.net/npm/details-polyfill@1/index.min.js"></script>
 
     <!-- import the Mustache library -->
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/mustache.js/3.0.0/mustache.min.js"></script>
+    <script src="https://unpkg.com/mustache@4.0.1/mustache.min.js"></script>
 
     <!-- Load d3-tsv -->
     <script src="https://d3js.org/d3-dsv.v1.min.js"></script>

--- a/public/index.html
+++ b/public/index.html
@@ -207,9 +207,6 @@
     <!-- Load Leaflet Marker Cluster plugin -->
     <script src="https://unpkg.com/leaflet.markercluster@1.4.1/dist/leaflet.markercluster-src.js"></script>
 
-    <!-- Load Promises polyfill -->
-    <script src="https://cdn.jsdelivr.net/npm/promise-polyfill@8/dist/polyfill.min.js"></script>
-
     <!-- Load Fetch polyfill -->
     <script src="https://cdn.jsdelivr.net/npm/whatwg-fetch@2.0.4/fetch.js"></script>
 

--- a/public/index.html
+++ b/public/index.html
@@ -208,7 +208,7 @@
     <script src="https://unpkg.com/leaflet.markercluster@1.4.1/dist/leaflet.markercluster-src.js"></script>
 
     <!-- Load Fetch polyfill -->
-    <script src="https://cdn.jsdelivr.net/npm/whatwg-fetch@3/fetch.js"></script>
+    <script src="https://unpkg.com/whatwg-fetch@3.0.0/dist/fetch.umd.js"></script>
 
     <!-- <details> element polyfill for IE -->
     <script src="//cdn.jsdelivr.net/npm/details-polyfill@1/index.min.js"></script>

--- a/public/index.html
+++ b/public/index.html
@@ -207,19 +207,13 @@
     <!-- Load Leaflet Marker Cluster plugin -->
     <script src="https://unpkg.com/leaflet.markercluster@1.4.1/dist/leaflet.markercluster-src.js"></script>
 
-    <!-- Load Promises polyfill -->
-    <script src="https://cdn.jsdelivr.net/npm/promise-polyfill@8/dist/polyfill.min.js"></script>
-
-    <!-- Load Fetch polyfill -->
-    <script src="https://cdn.jsdelivr.net/npm/whatwg-fetch@2.0.4/fetch.js"></script>
-
     <!-- <details> element polyfill for IE -->
     <script src="//cdn.jsdelivr.net/npm/details-polyfill@1/index.min.js"></script>
 
     <!-- import the Mustache library -->
     <script src="https://cdnjs.cloudflare.com/ajax/libs/mustache.js/3.0.0/mustache.min.js"></script>
 
-    <!-- Load d3-tsv -->
+    <!-- Load d3-tsv & d3-dispatch -->
     <script src="https://d3js.org/d3-dsv.v1.min.js"></script>
     <script src="https://d3js.org/d3-dispatch.v1.min.js"></script>
   </body>


### PR DESCRIPTION
Fixes #82 

https://deploy-preview-84--suspicious-easley-8d2764.netlify.app/

Since Babel's `preset-env` automagicially polyfills JS features based on the `browserlist` setting in `package.json` we shouldn't need the Promise polyfill.

Also bumping Leaflet to 1.6.0, was previously at 1.3.4