### PR TITLE
async fetch while drawing

### DIFF
--- a/src/utils/data.js
+++ b/src/utils/data.js
@@ -40,7 +40,7 @@ export async function getSheetsData(sheetId) {
 }
 
 export async function getData() {
-  for (let [key, layerConfig] of Object.entries(mapLayersConfig)) {
+  Object.entries(mapLayersConfig).forEach(async ([key, layerConfig]) => {
     try {
       const data =
         layerConfig.query !== null
@@ -50,5 +50,5 @@ export async function getData() {
     } catch (error) {
       handleFetchFailure("fetch-map-data-reject", error);
     }
-  }
+  });
 }


### PR DESCRIPTION
All I had to do was change the `for..of` loop to a `forEach`. The for loop waits for each await to finish so the next load doesn't stop till the whole loop is done. A `forEach` doesn't know what a promise is so it just goes ahead to start the next loading function while the previous one is drawing. 

You can see a mock of the difference between how the `for..of` and `forEach` work with `await` by running this repl.it: https://repl.it/@jimboweb/asyncTest

As with the previous PR it saves about a second and a half loading. Doesn't seem to have the problem of the previous PR had of the nation layer flashing.

@timhitchins, you might want to actually change your loading spinner a bit to stop after only the visible layers are drawn. It keeps spinning while the nation layer is generated even when the nation layer isn't being shown, making the user wait longer than they need. This will matter even more when we're not showing other layers because of i18n. 