### PR TITLE
Move 3rd party dependencies from CDN to Webpack

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -7,10 +7,7 @@
   "extends": "eslint:recommended",
   "globals": {
     "Atomics": "readonly",
-    "SharedArrayBuffer": "readonly",
-    "d3": "readonly",
-    "L": "readonly",
-    "Mustache": "readonly"
+    "SharedArrayBuffer": "readonly"
   },
   "plugins": [
     "babel"

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules/
 .DS_Store
 .env
 .idea
+yarn-error.log

--- a/package.json
+++ b/package.json
@@ -95,6 +95,13 @@
   },
   "dependencies": {
     "core-js": "^3.6.4",
-    "regenerator-runtime": "^0.13.5"
+    "d3-dispatch": "^1.0.6",
+    "d3-dsv": "^1.2.0",
+    "details-polyfill": "^1.1.0",
+    "leaflet": "^1.6.0",
+    "leaflet.markercluster": "^1.4.1",
+    "mustache": "^4.0.1",
+    "regenerator-runtime": "^0.13.5",
+    "whatwg-fetch": "^3.0.0"
   }
 }

--- a/public/index.html
+++ b/public/index.html
@@ -10,10 +10,20 @@
       content="Where officials have passed, or tenants are working to pass, housing protection legislation during the COVID-19 crisis, and where housing justice actions are occurring globally."
     />
     <!-- Load the Roboto font family -->
-    <link
-      href="https://fonts.googleapis.com/css?family=Roboto:400,700&display=swap"
-      rel="stylesheet"
-    />
+    <!-- see: https://csswizardry.com/2020/05/the-fastest-google-fonts/ -->
+    <link rel="preconnect"
+          href="https://fonts.gstatic.com"
+          crossorigin />
+    <link rel="preload"
+          as="style"
+          href="https://fonts.googleapis.com/css?family=Roboto:ital,wght@0,400;0,700;1,400;1,700&display=swap" />
+    <link rel="stylesheet"
+          href="https://fonts.googleapis.com/css?family=Roboto:ital,wght@0,400;0,700;1,400;1,700&display=swap"
+          media="print" onload="this.media='all'" />
+    <noscript>
+      <link rel="stylesheet"
+            href="https://fonts.googleapis.com/css?family=Roboto:ital,wght@0,400;0,700;1,400;1,700&display=swap" />
+    </noscript>
   </head>
   <body>
     <div id="root">

--- a/public/index.html
+++ b/public/index.html
@@ -9,22 +9,6 @@
       name="description"
       content="Where officials have passed, or tenants are working to pass, housing protection legislation during the COVID-19 crisis, and where housing justice actions are occurring globally."
     />
-
-    <!-- Load Leaflet CSS -->
-    <link
-      href="https://unpkg.com/leaflet@1.6.0/dist/leaflet.css"
-      rel="stylesheet"
-    />
-    <!-- Load the Marker Cluster CSS -->
-    <link
-      rel="stylesheet"
-      href="https://unpkg.com/leaflet.markercluster@1.4.1/dist/MarkerCluster.css"
-    />
-    <link
-      rel="stylesheet"
-      href="https://unpkg.com/leaflet.markercluster@1.4.1/dist/MarkerCluster.Default.css"
-    />
-
     <!-- Load the Roboto font family -->
     <link
       href="https://fonts.googleapis.com/css?family=Roboto:400,700&display=swap"
@@ -221,24 +205,5 @@
         {{/Resources}}
       </div>
     </script>
-
-    <!-- Load Leaflet library -->
-    <script src="https://unpkg.com/leaflet@1.6.0/dist/leaflet.js"></script>
-
-    <!-- Load Leaflet Marker Cluster plugin -->
-    <script src="https://unpkg.com/leaflet.markercluster@1.4.1/dist/leaflet.markercluster-src.js"></script>
-
-    <!-- Load Fetch polyfill -->
-    <script src="https://unpkg.com/whatwg-fetch@3.0.0/dist/fetch.umd.js"></script>
-
-    <!-- <details> element polyfill for IE -->
-    <script src="//cdn.jsdelivr.net/npm/details-polyfill@1/index.min.js"></script>
-
-    <!-- import the Mustache library -->
-    <script src="https://unpkg.com/mustache@4.0.1/mustache.min.js"></script>
-
-    <!-- Load d3-tsv -->
-    <script src="https://d3js.org/d3-dsv.v1.min.js"></script>
-    <script src="https://d3js.org/d3-dispatch.v1.min.js"></script>
   </body>
 </html>

--- a/src/components/InfoWindow.js
+++ b/src/components/InfoWindow.js
@@ -1,3 +1,4 @@
+import Mustache from "mustache";
 import { dispatch } from "utils/dispatch";
 
 export class InfoWindow {

--- a/src/components/LeafletMap.js
+++ b/src/components/LeafletMap.js
@@ -1,3 +1,10 @@
+import Mustache from "mustache";
+const L = Object.assign(
+  {},
+  require("leaflet"),
+  require("leaflet.markercluster")
+);
+
 import { dispatch } from "utils/dispatch";
 import {
   defaultMapConfig,

--- a/src/components/LeafletMap.js
+++ b/src/components/LeafletMap.js
@@ -1,9 +1,5 @@
 import Mustache from "mustache";
-const L = Object.assign(
-  {},
-  require("leaflet"),
-  require("leaflet.markercluster")
-);
+import L from "lib/leaflet";
 
 import { dispatch } from "utils/dispatch";
 import {

--- a/src/lib/leaflet.js
+++ b/src/lib/leaflet.js
@@ -1,0 +1,16 @@
+// NOTE: use this module for referencing Leaflet,
+// so that any Leaflet plugins are also available
+const L = Object.assign(
+  {},
+  require("leaflet"),
+  require("leaflet.markercluster")
+);
+
+export const rentStrikeIcon = new L.Icon({
+  iconUrl: "./assets/mapIcons/rent-strike.svg",
+  iconSize: [40, 40],
+  iconAnchor: [20, 20],
+  className: "icon-rent-strike",
+});
+
+export default L;

--- a/src/map-layers.js
+++ b/src/map-layers.js
@@ -1,3 +1,4 @@
+import * as L from "leaflet";
 import {
   colorNoData,
   fillColorScale,

--- a/src/map-layers.js
+++ b/src/map-layers.js
@@ -1,4 +1,4 @@
-import * as L from "leaflet";
+import L, { rentStrikeIcon } from "lib/leaflet";
 import {
   colorNoData,
   fillColorScale,
@@ -10,13 +10,6 @@ import {
 } from "utils/constants";
 import { renStrikeSheetId } from "./utils/config";
 import * as queries from "./utils/queries";
-
-const rentStrikeIcon = new L.Icon({
-  iconUrl: "./assets/mapIcons/rent-strike.svg",
-  iconSize: [40, 40],
-  iconAnchor: [20, 20],
-  className: "icon-rent-strike",
-});
 
 export const mapLayersConfig = {
   cities: {

--- a/src/styles/_map-marker-cluster.scss
+++ b/src/styles/_map-marker-cluster.scss
@@ -1,3 +1,6 @@
+@import "~leaflet.markercluster/dist/MarkerCluster.css";
+@import "~leaflet.markercluster/dist/MarkerCluster.Default.css";
+
 .marker-cluster,
 .marker-cluster > div {
   background-color: $rent-strike-color;

--- a/src/styles/_map.scss
+++ b/src/styles/_map.scss
@@ -1,3 +1,5 @@
+@import "~leaflet/dist/leaflet.css";
+
 #map {
   position: absolute;
   top: 0;

--- a/src/utils/data.js
+++ b/src/utils/data.js
@@ -1,3 +1,4 @@
+import { autoType, csvParse } from "d3-dsv";
 import { aempCartoAccount } from "./config";
 import { mapLayersConfig } from "../map-layers";
 import { dispatch } from "./dispatch";
@@ -36,7 +37,7 @@ export async function getSheetsData(sheetId) {
   }
 
   const text = await res.text();
-  return d3.csvParse(text, d3.autoType);
+  return csvParse(text, autoType);
 }
 
 export async function getData() {

--- a/src/utils/data.js
+++ b/src/utils/data.js
@@ -1,3 +1,5 @@
+// fetch polyfill for IE
+import "whatwg-fetch";
 import { autoType, csvParse } from "d3-dsv";
 import { aempCartoAccount } from "./config";
 import { mapLayersConfig } from "../map-layers";

--- a/src/utils/dispatch.js
+++ b/src/utils/dispatch.js
@@ -1,3 +1,4 @@
+import { dispatch as d3Dispatch } from "d3-dispatch";
 // d3-dispatch is a lightweight pub/sub module
 // for more see: https://github.com/d3/d3-dispatch
 
@@ -24,4 +25,4 @@ const events = [
  * dispatch.on("<event-name.sub-other-name>", <third callback function>)
  * etc...
  */
-export const dispatch = d3.dispatch(...events);
+export const dispatch = d3Dispatch(...events);

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -82,10 +82,11 @@ module.exports = (env, argv) => {
       // "alias" just means you can require/import a module using the name
       // rather the full path, e.g. import "styles/my.scss" vs. import "../styles/my.scss"
       alias: {
+        lib: path.resolve(__dirname, "src/lib"),
         styles: path.resolve(__dirname, "src/styles"),
         utils: path.resolve(__dirname, "src/utils"),
         public: path.resolve(__dirname, "public"),
-      },
+      }
     },
 
     /******************************************************************************

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -97,7 +97,7 @@ module.exports = (env, argv) => {
         // this "rule" tells webpack what "loaders" to use to process our CSS
         {
           // use a Regular Expression to tell webpack what type of file(s) this rule targets
-          test: /\.(s)css$/,
+          test: /\.(css|scss)$/,
           // tell webpack what "loaders" to use to process this file type
           use: [
             {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2186,7 +2186,7 @@ combined-stream@^1.0.6, combined-stream@~1.0.6:
   dependencies:
     delayed-stream "~1.0.0"
 
-commander@^2.18.0, commander@^2.20.0:
+commander@2, commander@^2.18.0, commander@^2.20.0:
   version "2.20.3"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
   integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
@@ -2652,6 +2652,20 @@ cyclist@^1.0.1:
   resolved "https://registry.yarnpkg.com/cyclist/-/cyclist-1.0.1.tgz#596e9698fd0c80e12038c2b82d6eb1b35b6224d9"
   integrity sha1-WW6WmP0MgOEgOMK4LW6xs1tiJNk=
 
+d3-dispatch@^1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/d3-dispatch/-/d3-dispatch-1.0.6.tgz#00d37bcee4dd8cd97729dd893a0ac29caaba5d58"
+  integrity sha512-fVjoElzjhCEy+Hbn8KygnmMS7Or0a9sI2UzGwoB7cCtvI1XpVN9GpoYlnb3xt2YV66oXYb1fLJ8GMvP4hdU1RA==
+
+d3-dsv@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/d3-dsv/-/d3-dsv-1.2.0.tgz#9d5f75c3a5f8abd611f74d3f5847b0d4338b885c"
+  integrity sha512-9yVlqvZcSOMhCYzniHE7EVUws7Fa1zgw+/EAV2BxJoG3ME19V6BQFBwI855XQDsxyOuG7NibqRMTtiF/Qup46g==
+  dependencies:
+    commander "2"
+    iconv-lite "0.4"
+    rw "1"
+
 dashdash@^1.12.0:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/dashdash/-/dashdash-1.14.1.tgz#853cfa0f7cbe2fed5de20326b8dd581035f6e2f0"
@@ -2809,6 +2823,11 @@ destroy@~1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/destroy/-/destroy-1.0.4.tgz#978857442c44749e4206613e37946205826abd80"
   integrity sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=
+
+details-polyfill@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/details-polyfill/-/details-polyfill-1.1.0.tgz#d6d71be0885560e7afca42688b03ff379fd80e56"
+  integrity sha512-YARtvrZ+FobZBMjfAyCxNZ5Cm5riB2tKMsdUQvTFnCvg3OeAkOGCoSxgDZT0uAXV+t5zgJYMGWd/ftVI6v8I0w==
 
 detect-file@^1.0.0:
   version "1.0.0"
@@ -4328,7 +4347,7 @@ husky@^4.2.5:
     slash "^3.0.0"
     which-pm-runs "^1.0.0"
 
-iconv-lite@0.4.24, iconv-lite@^0.4.24:
+iconv-lite@0.4, iconv-lite@0.4.24, iconv-lite@^0.4.24:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
   integrity sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==
@@ -5044,6 +5063,16 @@ lcid@^2.0.0:
   dependencies:
     invert-kv "^2.0.0"
 
+leaflet.markercluster@^1.4.1:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/leaflet.markercluster/-/leaflet.markercluster-1.4.1.tgz#b53f2c4f2ca7306ddab1dbb6f1861d5e8aa6c5e5"
+  integrity sha512-ZSEpE/EFApR0bJ1w/dUGwTSUvWlpalKqIzkaYdYB7jaftQA/Y2Jav+eT4CMtEYFj+ZK4mswP13Q2acnPBnhGOw==
+
+leaflet@^1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/leaflet/-/leaflet-1.6.0.tgz#aecbb044b949ec29469eeb31c77a88e2f448f308"
+  integrity sha512-CPkhyqWUKZKFJ6K8umN5/D2wrJ2+/8UIpXppY7QDnUZW5bZL5+SEI2J7GBpwh4LIupOKqbNSQXgqmrEJopHVNQ==
+
 leven@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/leven/-/leven-3.1.0.tgz#77891de834064cccba82ae7842bb6b14a13ed7f2"
@@ -5651,6 +5680,11 @@ multicast-dns@^6.0.1:
   dependencies:
     dns-packet "^1.3.1"
     thunky "^1.0.2"
+
+mustache@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/mustache/-/mustache-4.0.1.tgz#d99beb031701ad433338e7ea65e0489416c854a2"
+  integrity sha512-yL5VE97+OXn4+Er3THSmTdCFCtx5hHWzrolvH+JObZnUYwuaG7XV+Ch4fR2cIrcYI0tFHxS7iyFYl14bW8y2sA==
 
 mute-stream@0.0.8:
   version "0.0.8"
@@ -7466,6 +7500,11 @@ run-queue@^1.0.0, run-queue@^1.0.3:
   dependencies:
     aproba "^1.1.1"
 
+rw@1:
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/rw/-/rw-1.3.3.tgz#3f862dfa91ab766b14885ef4d01124bfda074fb4"
+  integrity sha1-P4Yt+pGrdmsUiF700BEkv9oHT7Q=
+
 rxjs@^6.5.3, rxjs@^6.5.5:
   version "6.5.5"
   resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.5.5.tgz#c5c884e3094c8cfee31bf27eb87e54ccfc87f9ec"
@@ -9164,6 +9203,11 @@ websocket-extensions@>=0.1.1:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/websocket-extensions/-/websocket-extensions-0.1.3.tgz#5d2ff22977003ec687a4b87073dfbbac146ccf29"
   integrity sha512-nqHUnMXmBzT0w570r2JpJxfiSD1IzoI+HGVdd3aZ0yNi3ngvQ4jv1dtHt5VGxfI2yj5yqImPhOK4vmIh2xMbGg==
+
+whatwg-fetch@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz#fc804e458cc460009b1a2b966bc8817d2578aefb"
+  integrity sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q==
 
 which-module@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
Resolves #93 

\+ uses [this nifty trick](https://csswizardry.com/2020/05/the-fastest-google-fonts/) to speed up the load time of the Roboto font from Google's CDN.

**Note:** this does significantly increase the amount of code we're shipping in the `vendors.js` bundle to ~247k, though we were very likely loading more than that using the un-minified versions of some 3rd party libraries (such as Leaflet) from various CDNs. There's also the benefit of shipping our static assets from a single domain rather than multiple domains, which should help speed things up.