### PR TITLE
[RFC] substituted basemap for i18n.

### DIFF
--- a/src/components/LeafletMap.js
+++ b/src/components/LeafletMap.js
@@ -57,7 +57,7 @@ export class LeafletMap {
       .addTo(this.map);
 
     this.basemapLayer = L.tileLayer(
-      "https://a.basemaps.cartocdn.com/rastertiles/light_all/{z}/{x}/{y}@2x.png",
+      "https://a.tile.openstreetmap.org/{z}/{x}/{y}.png",
       {
         minZoom: 1,
         maxZoom: 18,


### PR DESCRIPTION
Request for comments: consider changing to a basemap that uses local languages for locations outside the US.

Here is the use policy for OSM tiles used in this PR: 
https://operations.osmfoundation.org/policies/tiles/

Since tiles are cached by the user and this is not a commercial application, I think the AEMP usage would not qualify as "heavy usage" according to the OSM policy. Opening this PR for discussion.