### PR TITLE
Fixes Housing Action Layer: Use date column

### DIFF
--- a/src/utils/queries.js
+++ b/src/utils/queries.js
@@ -65,7 +65,7 @@ export const housingActionsCartoQuery = `
       WHEN strike_status IN ('Unsure / No estoy segurx / 不确定 / Pas sûr.e.s.', 'No') THEN 'No'
       ELSE 'Unsure'
     END AS status,
-    TO_CHAR(start :: DATE, 'Month d, yyyy') as start,
+    TO_CHAR(date :: DATE, 'Month d, yyyy') as start,
     the_geom, location, why, resources
   FROM ${cartoHousingActionsTable}
   WHERE the_geom IS NOT NULL;


### PR DESCRIPTION
The housing action layer was broken because the column for the start date changed names from `start` to `date`. One thing this brought up though, is that when a layer fails to load, it automatically ends the loading circle. This may not be the best way to display this, but I'm not exactly sure. Either way, this fixes the issue :)