### PR TITLE
Change default zoom, and zoom on search

### DIFF
--- a/src/components/LeafletMap.js
+++ b/src/components/LeafletMap.js
@@ -40,9 +40,10 @@ export class LeafletMap {
       zoomControl: false,
       attributionControl: false,
       maxBounds: [
-        [-85.05, -320], // lower left
-        [85.05, 200], // upper right
+        [-85.05, -220], // lower left
+        [85.05, 230], // upper right
       ],
+      minZoom: 3,
       maxZoom: 12,
     });
 
@@ -71,7 +72,7 @@ export class LeafletMap {
     this.basemapLayer = L.tileLayer(
       "https://{s}.basemaps.cartocdn.com/dark_nolabels/{z}/{x}/{y}{r}.png",
       {
-        minZoom: 1,
+        minZoom: 3,
         maxZoom: 18,
       }
     ).addTo(this.map);

--- a/src/components/LeafletMap.js
+++ b/src/components/LeafletMap.js
@@ -40,7 +40,7 @@ export class LeafletMap {
       zoomControl: false,
       attributionControl: false,
       maxBounds: [
-        [-85.05, -190], // lower left
+        [-85.05, -320], // lower left
         [85.05, 200], // upper right
       ],
       maxZoom: 12,
@@ -295,7 +295,7 @@ export class LeafletMap {
       let resource = location.resourceSets[0].resources[0];
       let center = resource.point.coordinates;
       const markerIcon = L.icon({ iconUrl: L.Icon.Default });
-      this.map.setView(center, 5);
+      this.map.setView(center, 8);
       const marker = new L.marker(center, { icon: markerIcon });
       marker.addTo(this.map);
       let markerContent = `

--- a/src/components/LeafletMap.js
+++ b/src/components/LeafletMap.js
@@ -43,7 +43,7 @@ export class LeafletMap {
         [-85.05, -220], // lower left
         [85.05, 230], // upper right
       ],
-      minZoom: 3,
+      minZoom: 2,
       maxZoom: 12,
     });
 
@@ -72,7 +72,7 @@ export class LeafletMap {
     this.basemapLayer = L.tileLayer(
       "https://{s}.basemaps.cartocdn.com/dark_nolabels/{z}/{x}/{y}{r}.png",
       {
-        minZoom: 3,
+        minZoom: 2,
         maxZoom: 18,
       }
     ).addTo(this.map);

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -31,7 +31,7 @@ export const DESKTOP_BREAKPOINT = 1200;
 export const defaultMapConfig = {
   lat: 40.27,
   lng: -43.74,
-  z: 2,
+  z: 3,
   nations: true,
   states: true,
   cities: true,

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -29,8 +29,8 @@ export const MOBILE_BREAKPOINT = 640;
 export const DESKTOP_BREAKPOINT = 1200;
 
 export const defaultMapConfig = {
-  lat: 40.27,
-  lng: -43.74,
+  lat: 45.356488,
+  lng: 12.771901,
   z: 3,
   nations: true,
   states: true,


### PR DESCRIPTION
Moves the maxbounds further east, so the user can pan to the west coast of the USA and South America when at a minimum zoom. Unfortunately it makes it possible to pan further east than intended, but this is probably worth it.