### PR TITLE
Move action type to top, remove striking

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -330,8 +330,12 @@
           <p>
             <strong data-i18n="infowindow.action.loc-label"></strong> {{location}}
           </p>
-          <p><strong data-i18n="infowindow.action.status-label"></strong> {{status}}</p>
         </div>
+        {{#strike_type}}
+        <div>
+          <p><strong data-i18n="infowindow.action.strike-type-label"></strong> {{strike_type}}</p>
+        </div>
+        {{/strike_type}}
         {{#why}}
         <div>
           <p><strong data-i18n="infowindow.action.why-label"></strong> {{why}}</p>
@@ -342,11 +346,6 @@
           <p><strong data-i18n="infowindow.action.start-date-label"></strong> {{start}}</p>
         </div>
         {{/start}}
-        {{#strike_type}}
-        <div>
-          <p><strong data-i18n="infowindow.action.strike-type-label"></strong> {{strike_type}}</p>
-        </div>
-        {{/strike_type}}
         {{#resources}}
         <div>
           <p><strong data-i18n="infowindow.action.resources-label"></strong> {{resources}}</p>
@@ -356,76 +355,76 @@
     </script>
 
     <script id="search-result-infowindow-template" type="x-tmpl-mustache">
-      
-        <div>
-          <p>
-            <strong data-i18n="infowindow.policy.jurisdictionType.{{jurisdictionTypeI18n}}"></strong><strong>: </strong>{{jurisdictionname}}
-          </p>
-        </div>
 
-        {{#range}}
-        <div>
-          <p>
-            <strong data-i18n="infowindow.policy.strength-label"></strong>
-            <span class="policy-strength-color policy-strength-color--{{range}}" data-i18n="policy-strength.{{range}}"></span>
-          </p>
-        </div>
-        {{/range}}
+      <div>
+        <p>
+          <strong data-i18n="infowindow.policy.jurisdictionType.{{jurisdictionTypeI18n}}"></strong><strong>: </strong>{{jurisdictionname}}
+        </p>
+      </div>
 
-        {{#endDateEarliest}}
-        <div>
-          <p><strong data-i18n="infowindow.policy.protections-end-label"></strong> {{endDateEarliest}}</p>
-        </div>
-        {{/endDateEarliest}}
+      {{#range}}
+      <div>
+        <p>
+          <strong data-i18n="infowindow.policy.strength-label"></strong>
+          <span class="policy-strength-color policy-strength-color--{{range}}" data-i18n="policy-strength.{{range}}"></span>
+        </p>
+      </div>
+      {{/range}}
 
-        {{#endDateLegist}}
-        <div>
-          <p><strong data-i18n="infowindow.policy.legislative-end-label"></strong> {{endDateLegist}}</p>
-        </div>
-        {{/endDateLegist}}
+      {{#endDateEarliest}}
+      <div>
+        <p><strong data-i18n="infowindow.policy.protections-end-label"></strong> {{endDateEarliest}}</p>
+      </div>
+      {{/endDateEarliest}}
 
-        {{#endDateRentRelief}}
-        <div>
-          <p><strong data-i18n="infowindow.policy.rent-relief-end-label"></strong> {{endDateRentRelief}}</p>
-        </div>
-        {{/endDateRentRelief}}
+      {{#endDateLegist}}
+      <div>
+        <p><strong data-i18n="infowindow.policy.legislative-end-label"></strong> {{endDateLegist}}</p>
+      </div>
+      {{/endDateLegist}}
 
-        {{#endDateCourt}}
-        <div>
-          <p><strong data-i18n="infowindow.policy.court-closure-end-label"></strong> {{endDateCourt}}</p>
-        </div>
-        {{/endDateCourt}}
+      {{#endDateRentRelief}}
+      <div>
+        <p><strong data-i18n="infowindow.policy.rent-relief-end-label"></strong> {{endDateRentRelief}}</p>
+      </div>
+      {{/endDateRentRelief}}
 
-        {{#policy_summary}}
-        <div>
-          <p><strong data-i18n="infowindow.policy.summary-label"></strong></p>
-          <p>{{policy_summary}}</p>
-        </div>
-        {{/policy_summary}}
+      {{#endDateCourt}}
+      <div>
+        <p><strong data-i18n="infowindow.policy.court-closure-end-label"></strong> {{endDateCourt}}</p>
+      </div>
+      {{/endDateCourt}}
 
-        {{#start}}
-        <div>
-          <p><strong data-i18n="infowindow.policy.start-date-label"></strong> {{start}}</p>
-        </div>
-        {{/start}}
+      {{#policy_summary}}
+      <div>
+        <p><strong data-i18n="infowindow.policy.summary-label"></strong></p>
+        <p>{{policy_summary}}</p>
+      </div>
+      {{/policy_summary}}
 
-        {{#_end}}
-        <div>
-          <p><strong data-i18n="infowindow.policy.end-date-label"></strong> {{end}}</p>
-        </div>
-        {{/_end}}
+      {{#start}}
+      <div>
+        <p><strong data-i18n="infowindow.policy.start-date-label"></strong> {{start}}</p>
+      </div>
+      {{/start}}
 
-        {{#link}}
-        <div>
-          <p class="infowindow-link"><a target="_blank" href="{{link}}" rel="noopener noreferrer" data-i18n="infowindow.policy.info-link"></a></p>
-        </div>
-        {{/link}}
+      {{#_end}}
+      <div>
+        <p><strong data-i18n="infowindow.policy.end-date-label"></strong> {{end}}</p>
+      </div>
+      {{/_end}}
 
-        {{#resource}}
-        <div>
-          <p class="infowindow-link"><a target="_blank" href="{{resource}}" rel="noopener noreferrer" data-i18n="infowindow.policy.resource-link"></a></p>
-        </div>
-        {{/resource}}
+      {{#link}}
+      <div>
+        <p class="infowindow-link"><a target="_blank" href="{{link}}" rel="noopener noreferrer" data-i18n="infowindow.policy.info-link"></a></p>
+      </div>
+      {{/link}}
+
+      {{#resource}}
+      <div>
+        <p class="infowindow-link"><a target="_blank" href="{{resource}}" rel="noopener noreferrer" data-i18n="infowindow.policy.resource-link"></a></p>
+      </div>
+      {{/resource}}
     </script>
 
     <!-- Leaflet map SVG patterns -->

--- a/src/locale/de.json
+++ b/src/locale/de.json
@@ -57,7 +57,6 @@
     "action": {
       "title": "Aktionen für das Recht auf Wohnen",
       "loc-label": "Ort:",
-      "status-label": "Situation:",
       "why-label": "Auslöser der Aktion:",
       "strike-type-label": "Art der Aktion:",
       "start-date-label": "Beginn:",

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -57,7 +57,6 @@
     "action": {
       "title": "Housing Justice Action",
       "loc-label": "Location:",
-      "status-label": "Rent striking?",
       "why-label": "Why?",
       "strike-type-label": "Action Type:",
       "start-date-label": "Start:",

--- a/src/locale/es.json
+++ b/src/locale/es.json
@@ -57,7 +57,6 @@
     "action": {
       "title": "Movilización por el derecho a la vivienda",
       "loc-label": "Localización:",
-      "status-label": "Status:",
       "why-label": "¿Por qué?",
       "strike-type-label": "Tipo de movilización:",
       "start-date-label": "Inicio:",

--- a/src/locale/it.json
+++ b/src/locale/it.json
@@ -61,7 +61,6 @@
     "action": {
       "title": "Iniziative in difesa dell'abitare",
       "loc-label": "Luogo:",
-      "status-label": "Situazione:",
       "why-label": "Perché?",
       "strike-type-label": "Action Type:",
       "start-date-label": "Inizio:",

--- a/src/locale/pt-BR.json
+++ b/src/locale/pt-BR.json
@@ -57,7 +57,6 @@
     "action": {
       "title": "Ação em defesa do direito de acesso à moradia",
       "loc-label": "Localização:",
-      "status-label": "Situação:",
       "why-label": "Por quê?",
       "strike-type-label": "Tipo de ação:",
       "start-date-label": "Início:",


### PR DESCRIPTION
Resolves: https://github.com/antievictionmappingproject/covid-19-map/issues/140

* Moves "action type" above the "why" section in rent strike popup.
* Removes the "status" section on rent strike popup.
* Removes unneeded status label in localisation files.